### PR TITLE
Add xfixes to package dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG
 
 # Checks for dependencies.
-PKG_CHECK_MODULES(X11, x11 xext xextproto)
+PKG_CHECK_MODULES(X11, x11 xext xextproto xfixes)
 AC_SUBST(X11_CFLAGS)
 AC_SUBST(X11_LIBS)
 


### PR DESCRIPTION
It provides "X11/extensions/Xfixes.h".

Thanks to @kwizart for pointing to it.