### PR TITLE
Add udev rules for tegra_vde

### DIFF
--- a/contrib/70-tegra_vde.rules
+++ b/contrib/70-tegra_vde.rules
@@ -1,0 +1,1 @@
+KERNEL=="tegra_vde", NAME="tegra_vde", GROUP="video", MODE="0666"


### PR DESCRIPTION

Btw, Is there a way to use 660 instead of 0666 like others dri devices ?

ls -al /dev/dri/{card0,renderD128}
crw-rw----+ 1 root video 226,   0 24 juil. 08:26 /dev/dri/card0
crw-rw----+ 1 root video 226, 128 24 juil. 08:26 /dev/dri/renderD128
