### PR TITLE
Fixup udevdir installation to not depend on prefix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = src
 
 ACLOCAL_AMFLAGS = -I m4
-udevrulesdir = $(prefix)$(udevdir)/rules.d
+udevrulesdir = $(udevdir)/rules.d
 dist_udevrules_DATA = contrib/70-tegra_vde.rules


### PR DESCRIPTION
This lead to /usr/usr/lib/udev/rules.d/ which
is not intended